### PR TITLE
Add required property to schema mapped form inputs

### DIFF
--- a/src/containers/doc.js
+++ b/src/containers/doc.js
@@ -1,4 +1,3 @@
-import { head } from 'lodash';
 import React, { Component, createFactory, DOM, PropTypes } from 'react';
 import { connect } from 'react-redux';
 import form from '../components/form';
@@ -9,7 +8,7 @@ const Form = createFactory(form);
 export class Doc extends Component {
   render() {
     const { schemaProps, doc } = this.props;
-    const inputs = head(mapSchemaToFormInputs(schemaProps, doc));
+    const inputs = mapSchemaToFormInputs(schemaProps, doc);
 
     return DOM.div({ className: 'section' }, Form(null, inputs));
   }

--- a/test/lib/transformers/schema.js
+++ b/test/lib/transformers/schema.js
@@ -49,64 +49,63 @@ describe('./lib/transformers/schema', function() {
       this.schema = ValidSchema.sheep;
     });
 
-    it('must return array of objects', function() {
+    it('must return an object', function() {
       const data = [
         { id: 1, name: 'garry' },
         { id: 2, name: 'larry' }
       ];
       const result = mapSchemaToFormInputs(this.schema, data);
 
-      result.must.be.an.array();
-      result[0].must.be.an.object();
+      result.must.be.an.object();
     });
 
     it('must not return type = string', function() {
       const data = { id: 1 };
       const result = mapSchemaToFormInputs(this.schema, data);
 
-      result[0].id.type.must.not.eql('string');
+      result.id.type.must.not.eql('string');
     });
 
     it('must return type = string as type = text', function() {
       const data = { id: 1 };
       const result = mapSchemaToFormInputs(this.schema, data);
 
-      result[0].id.type.must.eql('text');
+      result.id.type.must.eql('text');
     });
 
     it('must not return faker property', function() {
       const data = { id: 1 };
       const result = mapSchemaToFormInputs(this.schema, data);
 
-      result[0].must.not.have.property('faker');
+      result.must.not.have.property('faker');
     });
 
     it('must return value property', function() {
       const data = { id: 1 };
       const result = mapSchemaToFormInputs(this.schema, data);
 
-      result[0].id.value.must.be(1);
+      result.id.value.must.be(1);
     });
 
     it('must not return value property if undefined', function() {
       const data = { id: 1, name: undefined };
       const result = mapSchemaToFormInputs(this.schema, data);
 
-      result[0].name.must.not.have.property('value');
+      result.name.must.not.have.property('value');
     });
 
     it('must add required property if found in schema', function() {
       const data = { id: 1, name: undefined };
       const result = mapSchemaToFormInputs(this.schema, data);
 
-      result[0].name.must.eql({ required: true, type: "text" });
+      result.name.must.eql({ required: true, type: "text" });
     });
 
     it('must not add required property if not required by schema', function() {
       const data = { id: 1, name: undefined };
       const result = mapSchemaToFormInputs(this.schema, data);
 
-      result[0].id.must.not.have.property('required');
+      result.id.must.not.have.property('required');
     });
   });
 


### PR DESCRIPTION
This branch adds `required` property to form inputs if it exists as a `required: ['prop']` on the schema.

**Other things**
- I've refactored the method logic in the schema transformer.  I've moved the denseness of the looping logic to just one method, leaving the public methods more readable.
- `.mapSchemaToFormInputs` now returns an `Object` not an `Array`.
