### PR TITLE
#54 - Replace fetch with api

### DIFF
--- a/src/components/creator.js
+++ b/src/components/creator.js
@@ -1,5 +1,6 @@
 import { form2js } from 'form2js';
 import React, { createElement, createFactory, PropTypes } from 'react';
+import * as api from '../lib/api';
 import { mapSchemaToFormInputs } from '../lib/transformers/schema';
 import Form from './form';
 
@@ -17,17 +18,6 @@ module.exports = React.createClass({
     return { createButtonText: 'Create' };
   },
 
-  postData: function(data) {
-    fetch(this.props.apiUrl+'/'+this.props.pluralName, {
-      method: 'POST',
-      headers: {
-        'Accept': 'application/json',
-        'Content-Type': 'application/json'
-      },
-      body: JSON.stringify(data)
-    });
-  },
-
   handleNumbers: function(node) {
     if (node.nodeName === 'INPUT' && node.type === 'number') {
       const val = parseInt(node.value);
@@ -40,8 +30,9 @@ module.exports = React.createClass({
   submissionHandler: function(e) {
     e.preventDefault();
     const data = form2js(e.target, '.', true, this.handleNumbers);
+
     // FIXME check this data against the schema
-    this.postData(data);
+    api.post(this.props.pluralName, data);
   },
 
   toggleCreationForm: function() {

--- a/src/containers/main.js
+++ b/src/containers/main.js
@@ -5,6 +5,7 @@ import { resolve } from 'react-resolver';
 import header from '../components/header';
 import nav from '../components/nav';
 import listener from '../components/socket_listener';
+import * as api from '../lib/api';
 import {
   getApiSuccess,
   updateApiChangefeedState
@@ -54,15 +55,13 @@ const Connected = connect(state => ({
   collections: state.collections
 }));
 
-const Resolved = resolve('init', ({ api, dispatch }) => {
-  if (api.schema) return;
+const Resolved = resolve('init', ({ api: stateApi, dispatch }) => {
+  if (stateApi.schema) return;
 
-  return fetch(api.url + '/schema')
-    .then(res => res.json())
-    .then(json => {
-      dispatch(getApiSuccess(json));
-      dispatch(getCollectionsSuccess(Object.keys(json)));
-    });
+  return api.get('/schema').then(json => {
+    dispatch(getApiSuccess(json));
+    dispatch(getCollectionsSuccess(Object.keys(json)));
+  });
 });
 
 function recordEvent(collection, host, getState, dispatch, data) {


### PR DESCRIPTION
This branch resolves #54 by removing `fetch` and replacing it with `/lib/api`.

Note that within `Creator` the promise is still not returned (it wasn't previously), which will cause async issues but that can be resolved when `react-forms` is introduced with #40 .
